### PR TITLE
Subdomain dozent.ism.de used for teachers

### DIFF
--- a/lib/domains/de/ism/dozent.txt
+++ b/lib/domains/de/ism/dozent.txt
@@ -1,0 +1,1 @@
+International School of Management (ISM) Germany 


### PR DESCRIPTION
Subdomain dozent.ism.de used for teachers
https://en.ism.de/full-degree-students/bachelor-programs/bachelor-information-systems/program-content#2nd-semester
[screenshot_ism.pdf](https://github.com/acsig/swot/files/11202376/screenshot_ism.pdf)
